### PR TITLE
Error message when reading GPR files

### DIFF
--- a/R/global.R
+++ b/R/global.R
@@ -3211,8 +3211,8 @@ fill=TRUE,blank.lines.skip=TRUE,flush=TRUE,sep="\n")
     }
   }
 
-  nbTraces   = as.integer(as.character(headerHD[4,2]))
-  nbPt     = as.integer(as.character(headerHD[5,2]))
+ nbTraces   <- as.integer(as.character(headerHD[which(headerHD[,1]=="NUMBER OF TRACES"),2]))
+nbPt     <- as.integer(as.character(headerHD[which(headerHD[,1]=="NUMBER OF PTS/TRC"),2]))
   #----------------#
   #--- READ DT1 ---#
   dt1 <- file(fileNameDT1 , "rb")


### PR DESCRIPTION
Error message when reading GPR file:

> A<-readGPR("M00001.DT1")

Error in myData[, i] = readBin(dt1, what = integer(), n = nbPt, size =2) :
number of items to replace is not a multiple of replacement length

It seems that my DT1 files do not have the same listing as yours:
my NUMBER OF TRACES & NUMBER OF PTS/TRC are on lines 3 & 4, not 4 & 5
like yours.
This screwed up the trace and point numbers reading, so
I changed these 2 lines of codes in the function readDT1 (in global.R).
I re-installed the package and that solved the problem,
but it is maybe not the best solution.

Now I can read my files but I still have a Error message when plotting
the RGPR object.

> windows()
> plot(A)

Error in seq.default(1.1, by = 0.1, max(abs(y + 2 * time_0)) * v) :
wrong sign in 'by' argument

The plot was displayed but without the legend on the right.
I didn't try to solve this issue, but I still wonder if my DT1 file was
correctly read:
For example:
My slot A@traces goes 1 27 28 ... but I just have 8 traces in this GPR
file, so why does it "jump" from 1 to 27 ?
Same thing for A@pos.